### PR TITLE
chore(.huskyrc.json): added pre-commit support for the lib

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,0 +1,6 @@
+{
+  "hooks": {
+    "pre-commit": "npm run build",
+    "prepare-commit-msg": "exec < /dev/tty && git cz --hook"
+  }
+}


### PR DESCRIPTION
The support is added for the pre-commit in order to protect the versioning system from committing
the commits that failed during compipation and building the lib