### PR TITLE
fix: solved reloaded of validation rule group

### DIFF
--- a/projects/ngx-dhis2-validation-rule-filter/src/lib/components/validation-rule-group/ngx-dhis2-validation-rule-filter.component.ts
+++ b/projects/ngx-dhis2-validation-rule-filter/src/lib/components/validation-rule-group/ngx-dhis2-validation-rule-filter.component.ts
@@ -9,6 +9,7 @@ import {
   getValidationRuleGroupsLoaded,
   getValidationRuleGroupsLoading,
   getValidationRulePeriodTypes,
+  getValidationRuleGroupsReloaded,
 } from '../../store/selectors/validation-rule-groups.selectors';
 @Component({
   selector: 'lib-ngx-dhis2-validation-rule-filter',
@@ -21,6 +22,7 @@ export class NgxDhis2ValidationRuleFilterComponent implements OnInit {
   periodTypes: Array<string>;
   loading$: Observable<boolean>;
   loaded$: Observable<boolean>;
+  reloaded$: Observable<boolean>;
   periodTypes$: Observable<Array<string>>;
 
   loadingMessage;
@@ -29,12 +31,17 @@ export class NgxDhis2ValidationRuleFilterComponent implements OnInit {
   @Output() update = new EventEmitter();
   @Output() close = new EventEmitter();
 
-  constructor(
-    private store: Store<State>
-  ) {}
+  constructor(private store: Store<State>) {}
 
   ngOnInit() {
     this.loadingMessage = 'Loading Validation...';
+    this.store.select(getAllValidationRuleGroups);
+    this.reloaded$ = this.store.select(getValidationRuleGroupsReloaded);
+    this.reloaded$.subscribe(status => {
+      if (status) {
+        this.store.dispatch(new LoadValidationRuleGroups(this.dataSelection));
+      }
+    });
     this.store
       .select(getAllValidationRuleGroups)
       .subscribe((state: Array<{ name: string; id: string }>) => {
@@ -42,8 +49,6 @@ export class NgxDhis2ValidationRuleFilterComponent implements OnInit {
           ? (this.availableValidationRuleGroups = state)
           : (this.availableValidationRuleGroups = []);
       });
-    this.store.dispatch(new LoadValidationRuleGroups(this.dataSelection));
-    this.store.select(getAllValidationRuleGroups);
     this.loaded$ = this.store.select(getValidationRuleGroupsLoaded);
     this.loading$ = this.store.select(getValidationRuleGroupsLoading);
     this.periodTypes$ = this.store.select(getValidationRulePeriodTypes);

--- a/projects/ngx-dhis2-validation-rule-filter/src/lib/store/reducers/validation-rule-groups.reducers.ts
+++ b/projects/ngx-dhis2-validation-rule-filter/src/lib/store/reducers/validation-rule-groups.reducers.ts
@@ -11,6 +11,7 @@ import * as _ from 'lodash';
 export interface State extends EntityState<ValidationRuleGroup> {
     selectedValidationRuleGroup: number | string | null;
     periodType: Array<string>;
+    reloaded: boolean;
     loaded: boolean;
     loading: boolean;
 }
@@ -23,6 +24,7 @@ export const defaultValidationRuleGroupState: State = {
     ids: [],
     entities: {},
     selectedValidationRuleGroup: null,
+    reloaded: false,
     periodType: null,
     loaded: false,
     loading: false,
@@ -50,6 +52,7 @@ export function reducer(state = initialState, action: VRGActionTypes): State {
                 {
                     ...state,
                     periodType: validationRuleGroups.periodType,
+                    reloaded: true,
                     loading: false,
                     loaded: true,
                 }

--- a/projects/ngx-dhis2-validation-rule-filter/src/lib/store/selectors/validation-rule-groups.selectors.ts
+++ b/projects/ngx-dhis2-validation-rule-filter/src/lib/store/selectors/validation-rule-groups.selectors.ts
@@ -30,6 +30,11 @@ export const getValidationRuleGroupsLoaded = createSelector(
     (validationRuleGroup: State) => validationRuleGroup.loaded
 );
 
+export const getValidationRuleGroupsReloaded = createSelector(
+    getValidationRuleGroupState,
+    (validationRuleGroup: State) => validationRuleGroup.reloaded
+);
+
 export const getValidationRuleGroupsLoading = createSelector(
     getValidationRuleGroupState,
     (validationRuleGroup: State) => validationRuleGroup.loading


### PR DESCRIPTION
This commit will add the support to stop reloading of the validation rule group on opening and
closing of the validation rule group component in the selection filter